### PR TITLE
PBXX-10441 add trace errors

### DIFF
--- a/alice/middleware/logger.go
+++ b/alice/middleware/logger.go
@@ -42,9 +42,11 @@ func (l *logger) Log(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// base fields that get added to each log entry
 		fields := logrus.Fields{
-			logFieldUserID:  GetInsecureUserIDFromContext(r.Context()),
-			logFieldMethod:  r.Method,
-			logFieldPath:    r.URL.String(),
+			logFieldUserID: GetInsecureUserIDFromContext(r.Context()),
+			logFieldMethod: r.Method,
+			logFieldPath:   r.URL.String(),
+			// this header comes from the data dog span information that gets injected
+			// every request from the headers
 			logFieldTraceID: r.Header.Get("X-Datadog-Trace-ID"),
 		}
 

--- a/alice/middleware/logger.go
+++ b/alice/middleware/logger.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/promoboxx/go-service/alice/middleware/lrw"
+
 	"github.com/promoboxx/go-glitch/glitch"
 	"github.com/promoboxx/go-service/alice/middleware/contextkey"
-	"github.com/promoboxx/go-service/alice/middleware/lrw"
 	"github.com/sirupsen/logrus"
 )
 
@@ -17,6 +18,7 @@ const (
 	logFieldStatusCode = "status_code"
 	logFieldPath       = "path"
 	logFieldError      = "error"
+	logFieldTraceID    = "dd.trace_id"
 )
 
 // Logger injects a logger into the context
@@ -34,15 +36,16 @@ func NewLogrusLogger(baseEntry *logrus.Entry, logRequests bool) Logger {
 	return &logger{entry: baseEntry, logRequests: logRequests}
 }
 
+// Log is the middleware for injecting a logger into the context that has
+// request specific information
 func (l *logger) Log(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		loggingResponseWriter := &lrw.LoggingResponseWriter{w, http.StatusOK, nil}
-
+		// base fields that get added to each log entry
 		fields := logrus.Fields{
-			logFieldRequestID: GetRequestIDFromContext(r.Context()),
-			logFieldUserID:    GetInsecureUserIDFromContext(r.Context()),
-			logFieldMethod:    r.Method,
-			logFieldPath:      r.URL.String(),
+			logFieldUserID:  GetInsecureUserIDFromContext(r.Context()),
+			logFieldMethod:  r.Method,
+			logFieldPath:    r.URL.String(),
+			logFieldTraceID: r.Header.Get("X-Datadog-Trace-ID"),
 		}
 
 		entry := l.entry.WithFields(fields)
@@ -51,17 +54,20 @@ func (l *logger) Log(h http.Handler) http.Handler {
 		ctx := context.WithValue(r.Context(), contextkey.ContextKeyLogger, entry)
 		r = r.WithContext(ctx)
 
-		h.ServeHTTP(loggingResponseWriter, r)
+		h.ServeHTTP(w, r)
 
 		responseFields := fields
-		responseFields[logFieldStatusCode] = loggingResponseWriter.StatusCode
 
-		if loggingResponseWriter.InnerError != nil {
-			fields[logFieldError] = loggingResponseWriter.InnerError
+		if loggingResponseWriter, ok := w.(*lrw.LoggingResponseWriter); ok {
+			responseFields[logFieldStatusCode] = loggingResponseWriter.StatusCode
 
-			if dataErr, ok := loggingResponseWriter.InnerError.(glitch.DataError); ok {
-				for k, v := range dataErr.GetFields() {
-					fields[k] = v
+			if loggingResponseWriter.InnerError != nil {
+				fields[logFieldError] = loggingResponseWriter.InnerError
+
+				if dataErr, ok := loggingResponseWriter.InnerError.(glitch.DataError); ok {
+					for k, v := range dataErr.GetFields() {
+						fields[k] = v
+					}
 				}
 			}
 		}

--- a/alice/middleware/trace/trace.go
+++ b/alice/middleware/trace/trace.go
@@ -1,12 +1,18 @@
 package trace
 
 import (
+	"log"
 	"net/http"
 
-	"github.com/opentracing/opentracing-go"
-	"github.com/promoboxx/go-service/alice/middleware"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 
 	"github.com/justinas/alice"
+	"github.com/opentracing/opentracing-go"
+	otext "github.com/opentracing/opentracing-go/ext"
+	"github.com/promoboxx/go-service/alice/middleware"
+	"github.com/promoboxx/go-service/alice/middleware/lrw"
 )
 
 type openTracingTimer struct {
@@ -22,27 +28,55 @@ func NewOpenTracingTimer() middleware.Timer {
 func (ott *openTracingTimer) Time(name string) alice.Constructor {
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			log := middleware.GetLoggerFromContext(r.Context())
+			// make the response writer a logging response writer so we can access the status code
+			w = &lrw.LoggingResponseWriter{w, http.StatusOK, nil}
 			var span opentracing.Span
 			ctx := r.Context()
+
+			// attempt to extract any span information in case this request is coming from somewhere
+			// that may have already set one
 			sctx, err := opentracing.GlobalTracer().Extract(opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(r.Header))
-			if err != nil && err != opentracing.ErrSpanContextNotFound {
-				log.Errorf("Error extracting headers from context: %v", err)
+			if err != nil && err != tracer.ErrSpanContextNotFound {
+				log.Printf("error extracting span data: %v", err)
 			}
 
 			// if there was no span context start one
 			if sctx == nil {
-				span, ctx = opentracing.StartSpanFromContext(r.Context(), name)
+				span, ctx = opentracing.StartSpanFromContext(r.Context(), "http.request")
 			} else {
-				span = opentracing.StartSpan(name, opentracing.ChildOf(sctx))
-				err = opentracing.GlobalTracer().Inject(span.Context(), opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(r.Header))
-				if err != nil {
-					log.Errorf("Error injecting headers: %v", err)
-				}
+				// start a new span as a child of the existing span
+				span = opentracing.StartSpan("http.request", opentracing.ChildOf(sctx))
 			}
+
+			// required to get trace search and analytics
+			span.SetTag(ext.AnalyticsEvent, true)
+			// sets the name of the request that gets passed into measure
+			span.SetTag(ext.ResourceName, name)
+			span.SetTag(ext.HTTPURL, r.URL.String())
+			span.SetTag(ext.HTTPMethod, r.Method)
 			defer span.Finish()
 
+			// inject the span information into the http headers so when we send off to another internal
+			// service it will have the information to chain everything together
+			err = opentracing.GlobalTracer().Inject(span.Context(), opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(r.Header))
+			if err != nil {
+				log.Printf("error injecting span data: %v", err)
+			}
+
 			h.ServeHTTP(w, r.WithContext(ctx))
+
+			// set some tags based on status code
+			if lrw, ok := w.(*lrw.LoggingResponseWriter); ok {
+				otext.HTTPStatusCode.Set(span, uint16(lrw.StatusCode))
+
+				if lrw.StatusCode > 299 || lrw.StatusCode < 200 {
+					otext.Error.Set(span, true)
+
+					if lrw.InnerError != nil {
+						span.SetTag(ext.Error, lrw.InnerError)
+					}
+				}
+			}
 		})
 	}
 }


### PR DESCRIPTION
Adds:
1. Error tagging for traces
2. Status code tagging
3. HTTP method tagging
4. URL tagging
5. dd.trace_id to logs for linking logs to traces

Modifies:
1. Chain order to use the span middleware before the logging middleware. Which allows the logs to have the span ids

Removes:
1. RequestID middleware since it will not be used with trace_ids