### PR TITLE
Rework pagination parsing based on recent conversations

### DIFF
--- a/service/paging.go
+++ b/service/paging.go
@@ -6,8 +6,8 @@ import (
 )
 
 type Sort struct {
-	Field     string
-	Direction string
+	Field     string `json:"field"`
+	Direction string `json:"direction"`
 }
 
 func (s Sort) Valid(fieldWhiteList []string) bool {
@@ -28,9 +28,9 @@ func (s Sort) Valid(fieldWhiteList []string) bool {
 
 // PagingParams represents paging and sorting parameter values
 type PagingParams struct {
-	PageSize   *int32
-	Offset     *int32
-	SortFields []Sort
+	PageSize   *int32 `json:"page_size"`
+	Offset     *int32 `json:"offset"`
+	SortFields []Sort `json:"sort_fields"`
 }
 
 // ParsePagingParams retrieves paging params from the request, allows for whitelisting sort field values

--- a/service/paging.go
+++ b/service/paging.go
@@ -1,55 +1,74 @@
 package service
 
 import (
-	"fmt"
 	"net/http"
-	"strconv"
+	"strings"
 )
+
+type Sort struct {
+	Field     string
+	Direction string
+}
+
+func (s Sort) Valid(fieldWhiteList []string) bool {
+	if s.Field == "" || !contains(fieldWhiteList, s.Field) {
+		return false
+	}
+
+	switch s.Direction {
+	case "asc",
+		"desc":
+	// no-op
+	default:
+		return false
+	}
+
+	return true
+}
 
 // PagingParams represents paging and sorting parameter values
 type PagingParams struct {
 	PageSize   *int32
-	PageNumber *int32
-	SortField  *string
-	SortAsc    *bool
+	Offset     *int32
+	SortFields []Sort
 }
 
 // ParsePagingParams retrieves paging params from the request, allows for whitelisting sort field values
-func ParsePagingParams(r *http.Request, sortFieldsWhitelist []string) (PagingParams, error) {
-	paging := PagingParams{}
+func ParsePagingParams(r *http.Request, defaults PagingParams, sortFieldsWhitelist []string) (PagingParams, error) {
+	paging := defaults
 
-	// page number
-	pageNumber, err := Int32PointerFromQueryParam(r, "page_number")
+	// offset (page number)
+	offset, err := Int32PointerFromQueryParam(r, "offset")
 	if err != nil {
 		return paging, err
 	}
-	paging.PageNumber = pageNumber
+	if offset != nil {
+		paging.Offset = offset
+	}
 
 	// page size
 	pageSize, err := Int32PointerFromQueryParam(r, "page_size")
 	if err != nil {
 		return paging, err
 	}
-	paging.PageSize = pageSize
-
-	// sort asc
-	sortAscStr := r.URL.Query().Get("sort_asc")
-	if len(sortAscStr) > 0 {
-		sortAsc, err := strconv.ParseBool(sortAscStr)
-		if err != nil {
-			return paging, err
-		}
-		paging.SortAsc = &sortAsc
+	if pageSize != nil {
+		paging.PageSize = pageSize
 	}
 
-	// sort field
-	sortField := r.URL.Query().Get("sort_field")
-	if len(sortField) > 0 {
-		if !contains(sortFieldsWhitelist, sortField) {
-			sortFieldErr := fmt.Errorf("invalid sort field %s", sortField)
-			return paging, sortFieldErr
+	// Sort fields
+	sorts := strings.Split(r.URL.Query().Get("sort"), ",")
+	for _, sort := range sorts {
+		if sort != "" {
+			d := strings.Split(sort, ":")
+			s := Sort{
+				Field:     d[0],
+				Direction: d[1],
+			}
+
+			if valid := s.Valid(sortFieldsWhitelist); valid {
+				paging.SortFields = append(paging.SortFields, s)
+			}
 		}
-		paging.SortField = &sortField
 	}
 
 	return paging, nil

--- a/service/paging_test.go
+++ b/service/paging_test.go
@@ -4,109 +4,215 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestUnit_ParsePagingParams(t *testing.T) {
+func TestUnit_SortValid(t *testing.T) {
+	tests := map[string]struct {
+		validate func(t *testing.T)
+	}{
+		"base path": {
+			validate: func(t *testing.T) {
+				sort := Sort{
+					Field:     "foo",
+					Direction: "asc",
+				}
 
-	type testCase struct {
-		name     string
+				whiteList := []string{"bar", "hello", "foo", "world"}
+
+				require.True(t, sort.Valid(whiteList))
+			},
+		},
+		"exceptional path- field is empty": {
+			validate: func(t *testing.T) {
+				sort := Sort{
+					Field:     "",
+					Direction: "asc",
+				}
+
+				whiteList := []string{"bar", "hello", "foo", "world"}
+
+				require.False(t, sort.Valid(whiteList))
+			},
+		},
+		"exceptional path- field not whitelisted": {
+			validate: func(t *testing.T) {
+				sort := Sort{
+					Field:     "foo",
+					Direction: "asc",
+				}
+
+				whiteList := []string{"bar", "hello", "world"}
+
+				require.False(t, sort.Valid(whiteList))
+			},
+		},
+		"exceptional path- invalid direction": {
+			validate: func(t *testing.T) {
+				sort := Sort{
+					Field:     "foo",
+					Direction: "over-hill-over-dale",
+				}
+
+				whiteList := []string{"bar", "hello", "foo", "world"}
+
+				require.False(t, sort.Valid(whiteList))
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			tc.validate(t)
+		})
+	}
+}
+
+func TestUnit_ParsePagingParams(t *testing.T) {
+	tests := map[string]struct {
 		request  func(t *testing.T) *http.Request
 		validate func(t *testing.T, req *http.Request)
+	}{
+		"base path- no defaults": {
+			request: func(t *testing.T) *http.Request {
+				req, err := http.NewRequest("GET", "http://example.com?offset=1&page_size=100&sort=foo:asc", nil)
+				require.NoError(t, err)
+				return req
+			},
+			validate: func(t *testing.T, req *http.Request) {
+				pagingParams, err := ParsePagingParams(req, PagingParams{}, []string{"foo", "bar"})
+				require.NoError(t, err)
+
+				sortFields := []Sort{
+					{
+						Field:     "foo",
+						Direction: "asc",
+					},
+				}
+
+				require.Equal(t, int32(1), *pagingParams.Offset)
+				require.Equal(t, int32(100), *pagingParams.PageSize)
+				require.ElementsMatch(t, sortFields, pagingParams.SortFields)
+			},
+		},
+		"base path- all defaults set, no parameters in request": {
+			request: func(t *testing.T) *http.Request {
+				req, err := http.NewRequest("GET", "http://example.com", nil)
+				require.NoError(t, err)
+				return req
+			},
+			validate: func(t *testing.T, req *http.Request) {
+				offset := int32(1)
+				pageSize := int32(100)
+				defaults := PagingParams{
+					Offset:   &offset,
+					PageSize: &pageSize,
+					SortFields: []Sort{
+						{
+							Field:     "bar",
+							Direction: "desc",
+						},
+					},
+				}
+
+				pagingParams, err := ParsePagingParams(req, defaults, []string{"foo", "bar"})
+				require.NoError(t, err)
+
+				sortFields := []Sort{
+					{
+						Field:     "bar",
+						Direction: "desc",
+					},
+				}
+
+				require.Equal(t, int32(1), *pagingParams.Offset)
+				require.Equal(t, int32(100), *pagingParams.PageSize)
+				require.ElementsMatch(t, sortFields, pagingParams.SortFields)
+			},
+		},
+		"base path- default sorts provided, no sorts in request": {
+			request: func(t *testing.T) *http.Request {
+				req, err := http.NewRequest("GET", "http://example.com?offset=1&page_size=100", nil)
+				require.NoError(t, err)
+				return req
+			},
+			validate: func(t *testing.T, req *http.Request) {
+				defaults := PagingParams{
+					SortFields: []Sort{
+						{
+							Field:     "bar",
+							Direction: "desc",
+						},
+					},
+				}
+
+				pagingParams, err := ParsePagingParams(req, defaults, []string{"foo", "bar"})
+				require.NoError(t, err)
+
+				sortFields := []Sort{
+					{
+						Field:     "bar",
+						Direction: "desc",
+					},
+				}
+
+				require.Equal(t, int32(1), *pagingParams.Offset)
+				require.Equal(t, int32(100), *pagingParams.PageSize)
+				require.ElementsMatch(t, sortFields, pagingParams.SortFields)
+			},
+		},
+		"base path- no defaults, multiple sorts given": {
+			request: func(t *testing.T) *http.Request {
+				req, err := http.NewRequest("GET", "http://example.com?offset=1&page_size=100&sort=foo:asc,bar:desc", nil)
+				require.NoError(t, err)
+				return req
+			},
+			validate: func(t *testing.T, req *http.Request) {
+				pagingParams, err := ParsePagingParams(req, PagingParams{}, []string{"foo", "bar"})
+				require.NoError(t, err)
+
+				sortFields := []Sort{
+					{
+						Field:     "foo",
+						Direction: "asc",
+					},
+					{
+						Field:     "bar",
+						Direction: "desc",
+					},
+				}
+
+				require.Equal(t, int32(1), *pagingParams.Offset)
+				require.Equal(t, int32(100), *pagingParams.PageSize)
+				require.ElementsMatch(t, sortFields, pagingParams.SortFields)
+			},
+		},
+		"exceptional path- offset not an integer": {
+			request: func(t *testing.T) *http.Request {
+				req, err := http.NewRequest("GET", "http://example.com?offset=foo&page_size=100&sort_asc=true&sort_field=foo", nil)
+				require.NoError(t, err)
+				return req
+			},
+			validate: func(t *testing.T, req *http.Request) {
+				_, err := ParsePagingParams(req, PagingParams{}, []string{"foo"})
+				require.Error(t, err)
+			},
+		},
+		"exceptional path- page size not an integer": {
+			request: func(t *testing.T) *http.Request {
+				req, err := http.NewRequest("GET", "http://example.com?offset=100&page_size=foo&sort_asc=true&sort_field=foo", nil)
+				require.NoError(t, err)
+				return req
+			},
+			validate: func(t *testing.T, req *http.Request) {
+				_, err := ParsePagingParams(req, PagingParams{}, []string{"foo"})
+				require.Error(t, err)
+			},
+		},
 	}
 
-	tests := []testCase{
-		{
-			name: "happy path",
-			request: func(t *testing.T) *http.Request {
-				req, err := http.NewRequest("GET", "http://example.com?page_number=1&page_size=100&sort_asc=true&sort_field=foo", nil)
-				assert.Nil(t, err)
-				return req
-			},
-			validate: func(t *testing.T, req *http.Request) {
-				pagingParams, err := ParsePagingParams(req, []string{"foo", "bar"})
-				assert.Nil(t, err)
-
-				assert.Equal(t, int32(1), *pagingParams.PageNumber)
-				assert.Equal(t, int32(100), *pagingParams.PageSize)
-				assert.Equal(t, true, *pagingParams.SortAsc)
-				assert.Equal(t, "foo", *pagingParams.SortField)
-			},
-		},
-		{
-			name: "sort field not whitelisted",
-			request: func(t *testing.T) *http.Request {
-				req, err := http.NewRequest("GET", "http://example.com?page_number=1&page_size=100&sort_asc=true&sort_field=foo", nil)
-				assert.Nil(t, err)
-				return req
-			},
-			validate: func(t *testing.T, req *http.Request) {
-				_, err := ParsePagingParams(req, []string{"bar"})
-				assert.NotNil(t, err)
-			},
-		},
-		{
-			name: "sort field not included",
-			request: func(t *testing.T) *http.Request {
-				req, err := http.NewRequest("GET", "http://example.com?page_number=1&page_size=100&sort_asc=true", nil)
-				assert.Nil(t, err)
-				return req
-			},
-			validate: func(t *testing.T, req *http.Request) {
-				pagingParams, err := ParsePagingParams(req, []string{"bar"})
-				assert.Nil(t, err)
-
-				assert.Equal(t, int32(1), *pagingParams.PageNumber)
-				assert.Equal(t, int32(100), *pagingParams.PageSize)
-				assert.Equal(t, true, *pagingParams.SortAsc)
-				assert.Nil(t, pagingParams.SortField)
-			},
-		},
-		{
-			name: "page number not an integer",
-			request: func(t *testing.T) *http.Request {
-				req, err := http.NewRequest("GET", "http://example.com?page_number=foo&page_size=100&sort_asc=true&sort_field=foo", nil)
-				assert.Nil(t, err)
-				return req
-			},
-			validate: func(t *testing.T, req *http.Request) {
-				_, err := ParsePagingParams(req, []string{"foo"})
-				assert.NotNil(t, err)
-			},
-		},
-		{
-			name: "sort asc boolean parse error",
-			request: func(t *testing.T) *http.Request {
-				req, err := http.NewRequest("GET", "http://example.com?page_number=1&page_size=100&sort_asc=nope&sort_field=foo", nil)
-				assert.Nil(t, err)
-				return req
-			},
-			validate: func(t *testing.T, req *http.Request) {
-				_, err := ParsePagingParams(req, []string{"foo"})
-				assert.NotNil(t, err)
-			},
-		},
-		{
-			name: "sort asc missing, does not error",
-			request: func(t *testing.T) *http.Request {
-				req, err := http.NewRequest("GET", "http://example.com?page_number=1&page_size=100&sort_field=foo", nil)
-				assert.Nil(t, err)
-				return req
-			},
-			validate: func(t *testing.T, req *http.Request) {
-				pagingParams, err := ParsePagingParams(req, []string{"foo", "bar"})
-				assert.Nil(t, err)
-
-				assert.Equal(t, int32(1), *pagingParams.PageNumber)
-				assert.Equal(t, int32(100), *pagingParams.PageSize)
-				assert.Equal(t, "foo", *pagingParams.SortField)
-				assert.Nil(t, pagingParams.SortAsc)
-			},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
 			tc.validate(t, tc.request(t))
 		})
 	}


### PR DESCRIPTION
* `PageNumber` becomes `Offset`.
* `SortField` and `SortAsc` becomes a slice of new `Sort` struct.
* Parsing now expects a `sort` query parameter. It is comma delimited list of `<field>:<direction>` pairs.
* Unit tests for all the updates.