### PR TITLE
Added honeybadger notify to recovery middleware

### DIFF
--- a/alice/middleware/recovery.go
+++ b/alice/middleware/recovery.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"runtime"
 
+	"github.com/honeybadger-io/honeybadger-go"
 	"github.com/promoboxx/go-service/service"
 )
 
@@ -18,6 +19,8 @@ func Recovery(h http.Handler) http.Handler {
 				log := GetLoggerFromContext(r.Context())
 				stack := stack(3)
 				log.Printf("PANIC: %s\n%s", err, stack)
+
+				honeybadger.Notify(err)
 
 				service.WriteProblem(w, "An error occurred service your request.", "ERROR_SERVICE", http.StatusInternalServerError, nil)
 			}


### PR DESCRIPTION
I think this is the only place in `go-service` that we wanted to notify HoneyBadger, unless we also want to notify when a database connector fails to connect?