### PR TITLE
Added a context key for events producer

### DIFF
--- a/alice/middleware/contextkey/context.go
+++ b/alice/middleware/contextkey/context.go
@@ -9,4 +9,5 @@ const (
 	ContextKeyInsecureUserID
 	ContextKeyClaims
 	ContextKeyDBConn
+	ContextKeyProducer
 )


### PR DESCRIPTION
Added a context key for the events producer to make sure it doesn't conflict with other keys, even though we can't add the middleware step for injecting the producer itself here