### PR TITLE
setting resource name for datadog spans

### DIFF
--- a/graph/tracer.go
+++ b/graph/tracer.go
@@ -8,6 +8,8 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 
+	ddext "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+
 	opentracingLog "github.com/opentracing/opentracing-go/log"
 )
 
@@ -53,6 +55,7 @@ func (t tracer) InterceptOperation(ctx context.Context, next graphql.OperationHa
 	ext.SpanKind.Set(span, "server")
 	ext.Component.Set(span, "gqlgen")
 	span.SetTag("query", oc.RawQuery)
+	span.SetTag(ddext.ResourceName, oc.OperationName)
 	defer span.Finish()
 
 	return next(ctx)

--- a/service/helpers.go
+++ b/service/helpers.go
@@ -57,6 +57,8 @@ func WriteProblem(w http.ResponseWriter, detail, code string, status int, innerE
 
 	if lrw, ok := w.(*lrw.LoggingResponseWriter); ok {
 		lrw.InnerError = innerErr
+		lrw.AddLogField("error_code", code)
+		lrw.AddLogField("error_detail", detail)
 	}
 
 	if w != nil {
@@ -90,6 +92,8 @@ func WriteProblemWithMetadata(w http.ResponseWriter, detail, code string, status
 
 	if lrw, ok := w.(*lrw.LoggingResponseWriter); ok {
 		lrw.InnerError = innerErr
+		lrw.AddLogField("error_code", code)
+		lrw.AddLogField("error_detail", detail)
 	}
 
 	if w != nil {


### PR DESCRIPTION
# Adds
- setting errors for the spans, error message fields, setting the resource name to make these spans filterable in datadog